### PR TITLE
added conf saving option on every change

### DIFF
--- a/vdb_node_api/Models/Runtime/PeersBackgroundServiceSettings.cs
+++ b/vdb_node_api/Models/Runtime/PeersBackgroundServiceSettings.cs
@@ -4,6 +4,7 @@ public class PeersBackgroundServiceSettings
 {
 	public int PeersRenewIntervalSeconds { get; set; } = 0;
 	public int HandshakeAgoLimitSeconds { get; set; } = 0;
+	public bool SaveConfigOnEveryChange { get; set; } = false;
 
 	public PeersBackgroundServiceSettings(int peersRenewIntervalSeconds, int handshakeAgoLimitSeconds)
 	{

--- a/vdb_node_api/Services/EnvironmentProvider.cs
+++ b/vdb_node_api/Services/EnvironmentProvider.cs
@@ -9,6 +9,7 @@ public sealed class EnvironmentProvider
 	private const string ENV_DISABLE_GET_PEERS = "REST2WG_DISABLE_GET_PEERS";
 	private const string ENV_DISABLE_DELETE_PEERS = "REST2WG_DISABLE_DELETE_PEERS";
 	private const string ENV_DISABLE_STATUS_HMAC = "REST2WG_DISABLE_STATUS_HMAC";
+	private const string ENV_SAVE_CONFIG_ON_CHANGE = "REST2WG_SAVE_CONFIG_ON_CHANGE";
 	public bool? ALLOW_NOAUTH { get; init; } = null;
 	public string? AUTH_KEYHASH { get; init; } = null;
 	public int? HANDSHAKE_AGO_LIMIT { get; init; } = null;
@@ -16,6 +17,7 @@ public sealed class EnvironmentProvider
 	public bool? DISABLE_GET_PEERS { get; init; } = null;
 	public bool? DISABLE_DELETE_PEERS { get; init; } = null;
 	public bool? DISABLE_STATUS_HMAC { get; init; } = null;
+	public bool? SAVE_CONFIG_ON_CHANGE { get; init; } = null;
 
 	private readonly ILogger<EnvironmentProvider> _logger;
 
@@ -31,6 +33,7 @@ public sealed class EnvironmentProvider
 		DISABLE_GET_PEERS = ParseBoolValue(ENV_DISABLE_GET_PEERS);
 		DISABLE_DELETE_PEERS = ParseBoolValue(ENV_DISABLE_DELETE_PEERS);
 		DISABLE_STATUS_HMAC = ParseBoolValue(ENV_DISABLE_STATUS_HMAC);
+		SAVE_CONFIG_ON_CHANGE = ParseBoolValue(ENV_SAVE_CONFIG_ON_CHANGE);
 	}
 
 	private string GetIncorrectIgnoredMessage(string EnvName)

--- a/vdb_node_api/Services/SettingsProviderService.cs
+++ b/vdb_node_api/Services/SettingsProviderService.cs
@@ -48,6 +48,8 @@ public class SettingsProviderService
 				fromConf.PeersRenewIntervalSeconds = _environment.REVIEW_INTERVAL.Value;
 			if (_environment.HANDSHAKE_AGO_LIMIT is not null)
 				fromConf.HandshakeAgoLimitSeconds = _environment.HANDSHAKE_AGO_LIMIT.Value;
+			if(_environment.SAVE_CONFIG_ON_CHANGE is not null)
+				fromConf.SaveConfigOnEveryChange = _environment.SAVE_CONFIG_ON_CHANGE.Value;
 
 			return fromConf;
 		}

--- a/vdb_node_wireguard_manipulator/WgCommandsExecutor.cs
+++ b/vdb_node_wireguard_manipulator/WgCommandsExecutor.cs
@@ -41,11 +41,16 @@ public static class WgCommandsExecutor
 	{
 		return $"set wg0 peer \"{pubKey}\" remove";
 	}
+	private static string GetSaveConfigCommand()
+	{
+		return $"wg-quick save wg0";
+	}
 	private static string GetWgShowCommand(string wgInterfaceName = null!)
 	{
 		return wgInterfaceName is null ?
 			"show" : $"show {wgInterfaceName}";
 	}
+
 
 	public static async Task<string> AddPeer(string pubKey, string allowedIps)
 	{
@@ -55,6 +60,11 @@ public static class WgCommandsExecutor
 	{
 		return await RunCommand(GetRemovePeerCommand(pubKey));
 	}
+	public static async Task<string> SaveConfig()
+	{
+		return await RunCommand(GetSaveConfigCommand());
+	}
+
 
 	public static async Task<IEnumerator<WgShortPeerInfo>> GetPeersListEnumerator()
 	{


### PR DESCRIPTION
Added **SaveConfig** method call to the **EnsurePeerAdded** & **EnsurePeerRemoved** in PeersBackgroundService. Environment variable to set the behavior is **ENV_SAVE_CONFIG_ON_CHANGE**=true/false (default is false).